### PR TITLE
Add docstrings to units

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '0.7'
           - '1.0'
           - '1.1'
           - '1.2'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # UnitfulAtomic release notes
 
+## master
+
+* Add docstrings for all units ([#8](https://github.com/sostock/UnitfulAtomic.jl/pull/8)).
+* This release requires Julia ≥ 1.0 and Unitful ≥ 1.10 ([#8](https://github.com/sostock/UnitfulAtomic.jl/pull/8)).
+
 ## v1.0.0
 
 * Remove unnecessary code in `__init__()`

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ version = "1.0.0"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
-Unitful = "0.16, 0.17, 0.18, 1"
+Unitful = "1.10"
 julia = "0.7, 1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Unitful = "1.10"
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/UnitfulAtomic.jl
+++ b/src/UnitfulAtomic.jl
@@ -6,22 +6,134 @@ using Unitful: @unit, Dimension, Dimensions, NoDims, NoUnits, Units, dimension, 
 export auconvert, aunit, austrip
 
 # The following five constants are used as the “base” atomic units
+"""
+    UnitfulAtomic.me_au
+
+A unit equal to the electron rest mass mₑ ≈ 9.109,383,7015 × 10^-31 kg.
+Printed as "mₑ".
+
+`Unitful.me` is a quantity (with units `kg`) whereas `UnitfulAtomic.me_au` is a unit equal to
+`Unitful.me`.
+
+Dimension: [`Unitful.𝐌`](@ref).
+
+See also: `Unitful.me`, `Unitful.kg`.
+"""
 @unit me_au "mₑ"  ElectronRestMass      Unitful.me                     false
+"""
+    UnitfulAtomic.e_au
+
+A unit equal to the elementary charge e = 1.602,176,634 × 10^-19 C.
+Printed as "e".
+
+`Unitful.q` is a quantity (with units `C`) whereas `UnitfulAtomic.e_au` is a unit equal to
+`Unitful.q`.
+
+Dimension: 𝐈 𝐓.
+
+See also: `Unitful.q`, `Unitful.C`.
+"""
 @unit e_au  "e"   ElementaryCharge      Unitful.q                      false
+"""
+    UnitfulAtomic.ħ_au
+
+A unit equal to the reduced Planck constant ħ = h / 2π ≈ 1.054,571,8176 × 10^-34 J × s.
+Printed as "ħ".
+
+`Unitful.ħ` is a quantity (with units `J × s`) whereas `UnitfulAtomic.ħ_au` is a unit equal to
+`Unitful.ħ`.
+
+Dimension: 𝐋^2 𝐌 𝐓^-1.
+
+See also: `Unitful.ħ`, `Unitful.J`, `Unitful.s`.
+"""
 @unit ħ_au  "ħ"   ReducedPlanckConstant Unitful.ħ                      false
+"""
+    UnitfulAtomic.k_au
+
+A unit equal to the Boltzmann constant k = 1.380,649 × 10^-23 J / K.
+Printed as "k".
+
+`Unitful.k` is a quantity (with units `J / K`) whereas `UnitfulAtomic.k_au` is a unit equal to
+`Unitful.k`.
+
+Dimension: 𝐋^2 𝐌 𝚯^-1 𝐓^-2.
+
+See also: `Unitful.k`, `Unitful.J`, `Unitful.K`.
+"""
 @unit k_au  "k"   BoltzmannConstant     Unitful.k                      false
+"""
+    UnitfulAtomic.a0_au
+    UnitfulAtomic.bohr
+
+A unit equal to the Bohr radius
+```
+a₀ = 4π × ε0 × ħ^2 / (me × q^2)
+   ≈ 5.291,772,109,03 × 10^-11 m.
+```
+Printed as "a₀".
+
+Dimension: 𝐋.
+
+See also: `Unitful.ε0`, `Unitful.ħ`, `Unitful.me`, `Unitful.q`, `Unitful.m`.
+"""
 @unit a0_au "a₀"  BohrRadius            5.291_772_109_03e-11*Unitful.m false # CODATA 2018 recommended value
 
 # Hartree energy is derived from the base atomic units
+"""
+    UnitfulAtomic.Eh_au
+    UnitfulAtomic.hartree
+
+A unit equal to the Hartree energy
+```
+Eₕ = me × q^4 / (4π × ε0 × ħ)^2
+   ≈ 4.359,744,7222 × 10^-18 J
+   ≈ 27.211,386,246 eV.
+```
+Printed as "Eₕ".
+
+Dimension: 𝐋^2 𝐌 𝐓^-2.
+
+See also: `Unitful.me`, `Unitful.q`, `Unitful.ε0`, `Unitful.ħ`, `Unitful.J`, `Unitful.eV`, [`UnitfulAtomic.Ry`](@ref).
+"""
 @unit Eh_au "Eₕ"  HartreeEnergy         1ħ_au^2/(me_au*a0_au^2)       false
 
 # Units that are not Hartree atomic units, but are commonly used in atomic physics
+"""
+    UnitfulAtomic.Ry
+
+A unit equal to the Rydberg energy
+```
+Ry = Eₕ / 2 
+   = me × q^4 / (8 × ε0^2 × h^2)
+   ≈ 2.179,872,3611 × 10^-18 J
+   ≈ 13.605,693,1230 eV.
+```
+
+Dimension: 𝐋^2 𝐌 𝐓^-2.
+
+See also: [`UnitfulAtomic.Eh_au`](@ref), `Unitful.me`, `Unitful.q`, `Unitful.ε0`, `Unitful.h`, `Unitful.J`, `Unitful.eV`.
+"""
 @unit Ry    "Ry"  RydbergEnergy         Eh_au//2                      false
+"""
+    Unitful.μ_N
+
+A unit equal to the nuclear magneton
+```
+μ_N = q × ħ / (2 × mp)
+    ≈ 5.050,783,7461 × 10^-27 J / T
+    ≈ 3.152,451,258,44 × 10^-8 eV / T.
+```
+
+Dimension: 𝐈 𝐋^2.
+
+See also: `Unitful.q`, `Unitful.ħ`, `Unitful.mp`, `Unitful.J`, `Unitful.T`, `Unitful.eV`.
+"""
 @unit μ_N   "μ_N" NuclearMagneton       e_au*ħ_au/(2*Unitful.mp)      false
 
 # Aliases for units
-const bohr    = a0_au
-const hartree = Eh_au
+@doc @doc(a0_au) const bohr    = a0_au
+@doc @doc(Eh_au) const hartree = Eh_au
 
 """
     aunit(x::Unitful.Quantity)


### PR DESCRIPTION
This adds docstrings to all units defined by this package. This requires at least Unitful 1.10, which in turn requires Julia 1.0. Support for Julia 0.7 is therefore dropped.